### PR TITLE
Denial of Service (DoS), Vulnerable module xlsx Introduced through xls-parser@3.1.0, Fixed in xlsx@0.18.5 and above

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,6 @@
   ],
   "license": "ISC",
   "dependencies": {
-    "xlsx": "^0.14.1"
+    "xlsx": "^0.18.5"
   }
 }


### PR DESCRIPTION
Hello, I have been using xls-parser package, and I came across Denial of Service (DoS) Vulnerability (CVE-2021-32013) for **xlsx module**, And it is introduced through **xls-parser@3.1.0**. So to get rid of this **_vulnerability_** , we have to update the dev dependencies in xls parser. Kindly review and approve it. Thanks